### PR TITLE
Support for offset constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "rgbds-z80" extension will be documented in this file.
 
+## [4.0.1] - 2023-07-10
+
+### Added
+ - Support for offset constants (declared with `rb`, `rw` and `rl`).
+
 ## [4.0.0] - 2023-06-27
 
 Thanks to sukus21 for the improvements in this release!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rgbds-z80",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "rgbds-z80",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "dependencies": {
                 "xml-js": "~1.6.11"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rgbds-z80",
     "displayName": "RGBDS Z80",
     "description": "Language service for RGBDS GB Z80.",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "publisher": "donaldhays",
     "engines": {
         "vscode": "^1.22.0"

--- a/src/symbolDocumenter.ts
+++ b/src/symbolDocumenter.ts
@@ -17,7 +17,7 @@ const blockCommentEndRegex = /^(.*?)\s*\*\/.*$/
 const includeLineRegex = /^include[\s]+"([^"]+)".*$/i
 const spacerRegex = /^\s*(.)\1{3,}\s*$/
 const labelDefinitionRegex = /^\s*((?:[A-Z_]\w*)?(?:(?:\.[A-Z_]\w*:{0,2})|(?:[A-Z_]\w*:{1,2})))/i
-const defineExpressionRegex = /^[\s]*(?:def[\s]*)?([a-zA-Z_][a-zA-Z_0-9]*)[\s]+(equ|equs|set|=)[\s]+.*$/i
+const defineExpressionRegex = /^[\s]*(?:def[\s]*)?([A-Z_][\w]*)[\s]+(equ|equs|set|rb|rw|rl|=)[\s]+.*$/i
 const instructionRegex = new RegExp(`^(${syntaxInfo.instructions.join("|")})\\b`, "i");
 const keywordRegex = new RegExp(`^(${syntaxInfo.preprocessorKeywords.join("|")})\\b`, "i");
 const macroDefinitionRegex = /^\s*macro[\s]+([A-Z_]\w*).*$/i


### PR DESCRIPTION
Hi again!

I noticed that [offset constants](https://rgbds.gbdev.io/docs/v0.6.1/rgbasm.5#Offset_constants) weren't supported, so I went and added that in.

Constants defined with the `rb`, `rw` and `rl` keywords should now both appear in autocomplete, and have documentation.
```asm
DEF OFFSET_CONSTANT RB 1
DEF OFFSET_WORD RW 7
DEF OFFSET_LONG RL 3
```